### PR TITLE
bcrypt-ruby is now known as bcrypt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-identity (1.1.1)
-      bcrypt-ruby (~> 3.0)
+      bcrypt (~> 3.0)
       omniauth (~> 1.0)
 
 GEM
@@ -21,6 +21,7 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.5)
     arel (3.0.2)
+    bcrypt (3.1.7)
     bcrypt-ruby (3.0.1)
     bson (1.9.0)
     bson_ext (1.9.0)

--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '~> 1.0'
-  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  gem.add_runtime_dependency 'bcrypt', '~> 3.0'
 
   gem.add_development_dependency 'maruku', '~> 0.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
The bcrypt-ruby gem has changed to simply bcrypt. This change gets rid of the following message upon installing omniauth-identity:


     Post-install message from bcrypt-ruby:

     #######################################################

     The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of
     installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your
     dependencies accordingly.

     #######################################################
