### PR TITLE
change bcrypt-ruby dependency to bcrypt

### DIFF
--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '~> 1.0'
-  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  gem.add_runtime_dependency 'bcrypt', '~> 3.1'
 
   gem.add_development_dependency 'maruku', '~> 0.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
The `bcrypt-ruby` gem has been renamed to just `bcrypt`. This change removes the deprecation warning that shows when installing `bcrypt-ruby`.

Also update the version to `~> 3.1` since the lowest version of the `bcrypt` gem is 3.1.3